### PR TITLE
Add wait script to Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ FROM alpine:3.10
 
 COPY --from=builder /go/src/github.com/Factom-Asset-Tokens/fatd/fatd .
 
+ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.2.1/wait /wait
+RUN chmod +x /wait
+
 ENTRYPOINT [ "./fatd" ]


### PR DESCRIPTION
Adds [docker-compose-wait](https://github.com/ufoscout/docker-compose-wait/) into the Docker image. This script allows docker-compose to prevent fatd from starting until the factomd API is ready. This is necessary to ensure that fatd and factomd can be started together gracefully from docker-compose.

Can be used from docker-compose like:

```yaml
entrypoint: sh -c "/wait && ./fatd -s http://factomd:8088"
environment:
  WAIT_HOSTS: factomd:8088
```