### PR TITLE
[Fat-103] Initialize a distinct RNG for signing 

### DIFF
--- a/fat103/sign.go
+++ b/fat103/sign.go
@@ -10,6 +10,12 @@ import (
 	"github.com/Factom-Asset-Tokens/factom/jsonlen"
 )
 
+var rng *rand.Rand
+
+func init() {
+	rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+}
+
 // Sign the RCD/Sig ID Salt + Timestamp Salt + Chain ID Salt + Content of the
 // factom.Entry and add the RCD + signature pairs for the given addresses to
 // the ExtIDs. This clears any existing ExtIDs.
@@ -47,6 +53,6 @@ func Sign(e factom.Entry, signingSet ...factom.RCDSigner) factom.Entry {
 	return e
 }
 func newTimestampSalt() []byte {
-	timestamp := time.Now().Add(time.Duration(-rand.Int63n(int64(1 * time.Hour))))
+	timestamp := time.Now().Add(time.Duration(-rng.Int63n(int64(1 * time.Hour))))
 	return []byte(strconv.FormatInt(timestamp.Unix(), 10))
 }


### PR DESCRIPTION
This is a bug discovered by @ilzheev who submitted multiple individual transactions by queuing them up in the cli. When you run multiple instances of an application that just imports the fat103 package, all of the timestamps will be the same since golang does not initialize the default rng by default.

test code:
```
package main

import (
	"fmt"

	"github.com/Factom-Asset-Tokens/factom"
	"github.com/Factom-Asset-Tokens/fatd/fat103"
)

func main() {
	priv := factom.FsAddress{}
	var ent factom.Entry
	ent.ChainID = &factom.Bytes32{}
	ent = fat103.Sign(ent, priv)
	fmt.Println(ent.ExtIDs[0])
}
```

To test: build it and then execute it several times in a row. Any execution in the same second will result with the same "randomized" timestamp. The first random call used will always result in `1991947779410`, see https://play.golang.org/p/xTCPFq2Ghfb

Initializing a package instance of rand will fix this and make it work as intended.

(note: this issue also exists in fat's "factom" package)