### PR TITLE
build: clean up Dockerfile and upgrade base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13-alpine AS builder
+FROM golang:1.14-alpine AS builder
 
 RUN apk add make bash git gcc libc-dev
 
@@ -13,11 +13,8 @@ WORKDIR ${PKG_PATH}
 COPY . ${PKG_PATH}/
 RUN make
 
-FROM alpine:3.10
+FROM alpine:3.11
 
 COPY --from=builder /go/src/github.com/Factom-Asset-Tokens/fatd/fatd .
-
-ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.2.1/wait /wait
-RUN chmod +x /wait
 
 ENTRYPOINT [ "./fatd" ]


### PR DESCRIPTION
- Upgrade to Go 1.14
- Upgrade base image to alpine 3.11
- Remove downloading of docker compose wait utility (unused)